### PR TITLE
Add support for default time zone

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -3,6 +3,7 @@ AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 AWS_SES_REGION_NAME=eu-west-1
 DATABASE_URL=postgres://<user>@localhost/hyper-sentry-development
+DEFAULT_TIME_ZONE=Europe/Oslo
 EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
 PORT=9000
 REDIS_URL=redis://localhost:6379/

--- a/config.py
+++ b/config.py
@@ -43,6 +43,10 @@ SENTRY_ALLOW_PUBLIC_PROJECTS = False
 # SENTRY_ADMIN_EMAIL = 'your.name@example.com'
 SENTRY_ADMIN_EMAIL = ''
 
+# Default time zone for localization in the UI.
+# http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
+SENTRY_DEFAULT_TIME_ZONE = env('DEFAULT_TIME_ZONE', 'UTC')
+
 ###########
 ## Redis ##
 ###########


### PR DESCRIPTION
This would allow us to set the default zone through an environment variable.

Let's wait for getsentry/sentry@5f254776035fe394e3098bba511a3e0bf0454a3a to be released before QA'ing and merging this.
