### PR TITLE
Require configuring admin e-mail

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -7,7 +7,8 @@ EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
 PORT=9000
 REDIS_URL=redis://localhost:6379/
 SECRET_KEY=HnjZkpamxL4VSbpMx3S2rs2LiGZJsuTCqdpcFXYb7Dl8QJX7rtYp5A==
+SENTRY_ADMIN_EMAIL=sentry@localhost
 SENTRY_URL_PREFIX=http://localhost
-SERVER_EMAIL=sentry@hyper.no
+SERVER_EMAIL=sentry@localhost
 SSLIFY_DISABLE=False
 WEB_CONCURRENCY=3

--- a/config.py
+++ b/config.py
@@ -39,9 +39,7 @@ SENTRY_ALLOW_PUBLIC_PROJECTS = False
 # The administrative email for this installation.
 # Note: This will be reported back to getsentry.com as the point of contact. See
 # the beacon documentation for more information.
-
-# SENTRY_ADMIN_EMAIL = 'your.name@example.com'
-SENTRY_ADMIN_EMAIL = ''
+SENTRY_ADMIN_EMAIL = env('SENTRY_ADMIN_EMAIL', required=True)
 
 ###########
 ## Redis ##


### PR DESCRIPTION
This will allow configuring `SENTRY_ADMIN_EMAIL` through an environment variable, getting rid of this pesky start-up warning:

```
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!! SENTRY_ADMIN_EMAIL is not configured !!
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
```